### PR TITLE
Task: Neos 4.0 compatibility and callable in protected context

### DIFF
--- a/Classes/Dimaip/GroupBy/Eel/FlowQueryOperations/GroupByOperation.php
+++ b/Classes/Dimaip/GroupBy/Eel/FlowQueryOperations/GroupByOperation.php
@@ -60,7 +60,9 @@ class GroupByOperation extends AbstractOperation implements ProtectedContextAwar
     /**
      * @param \Neos\Eel\FlowQuery\FlowQuery $flowQuery
      * @param array $arguments
-     * @return array
+     * @return array|mixed|null
+     * @throws \Neos\Eel\Exception
+     * @throws \Neos\Eel\FlowQuery\FlowQueryException
      */
     public function evaluate(\Neos\Eel\FlowQuery\FlowQuery $flowQuery, array $arguments)
     {

--- a/Classes/Dimaip/GroupBy/Eel/FlowQueryOperations/GroupByOperation.php
+++ b/Classes/Dimaip/GroupBy/Eel/FlowQueryOperations/GroupByOperation.php
@@ -1,78 +1,86 @@
 <?php
 namespace Dimaip\GroupBy\Eel\FlowQueryOperations;
 
-use Neos\Flow\Annotations as Flow;
-use Neos\Eel\FlowQuery\Operations\AbstractOperation;
 use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\Eel\FlowQuery\Operations\AbstractOperation;
+use Neos\Flow\Annotations as Flow;
 
 /**
  * GroupBy Operation
  *
  * Takes an array of things and groups it by discriminator specified as as an Eel Expression
- *
  */
-class GroupByOperation extends AbstractOperation {
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @var string
-	 */
-	static protected $shortName = 'groupBy';
+class GroupByOperation extends AbstractOperation
+{
+    /**
+     * {@inheritdoc}
+     *
+     * @var string
+     */
+    static protected $shortName = 'groupBy';
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @var integer
-	 */
-	static protected $priority = 100;
+    /**
+     * {@inheritdoc}
+     *
+     * @var integer
+     */
+    static protected $priority = 100;
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @var boolean
-	 */
-	static protected $final = TRUE;
+    /**
+     * {@inheritdoc}
+     *
+     * @var boolean
+     */
+    static protected $final = true;
 
-	/**
-	 * {@inheritdoc}
-	 *
-	 * @param array (or array-like object) $context onto which this operation should be applied
-	 * @return boolean TRUE if the operation can be applied onto the $context, FALSE otherwise
-	 */
-	public function canEvaluate($context) {
-		return (isset($context[0]) && ($context[0] instanceof NodeInterface));
-	}
+    /**
+     * {@inheritdoc}
+     *
+     * @param array (or array-like object) $context onto which this operation should be applied
+     * @return boolean TRUE if the operation can be applied onto the $context, FALSE otherwise
+     */
+    public function canEvaluate($context)
+    {
+        return (isset($context[0]) && ($context[0] instanceof NodeInterface));
+    }
 
-	/**
-	 * @Flow\Inject
-	 * @var \Neos\Eel\EelEvaluatorInterface
-	 */
-	protected $eelEvaluator;
+    /**
+     * @Flow\Inject
+     * @var \Neos\Eel\EelEvaluatorInterface
+     */
+    protected $eelEvaluator;
 
-	/**
-	 * @Flow\InjectConfiguration(package="Neos.Fusion", path="defaultContext")
-	 * @var array
-	 */
-	protected $defaultContextConfiguration;
+    /**
+     * @Flow\InjectConfiguration(package="Neos.Fusion", path="defaultContext")
+     * @var array
+     */
+    protected $defaultContextConfiguration;
 
-	/**
-	 * @param \Neos\Eel\FlowQuery\FlowQuery $flowQuery
-	 * @param array $arguments
-	 * @return array
-	 */
-	public function evaluate(\Neos\Eel\FlowQuery\FlowQuery $flowQuery, array $arguments) {
-		if (!isset($arguments[0]) || empty($arguments[0])) {
-			throw new \Neos\Eel\FlowQuery\FlowQueryException('No Eel expression provided', 1332492243);
-		}
-		$expression = '${' . $arguments[0] . '}';
-		$context = $flowQuery->getContext();
-		$result = [];
-		foreach ($context as $node) {
-			$key = \Neos\Eel\Utility::evaluateEelExpression($expression, $this->eelEvaluator, array('node' => $node), $this->defaultContextConfiguration);
-			$key = is_string($key) ? $key : '_invalid';
-			$result[$key][] = $node;
-		}
-		ksort($result);
-		return $result;
-	}
+    /**
+     * @param \Neos\Eel\FlowQuery\FlowQuery $flowQuery
+     * @param array $arguments
+     * @return array
+     */
+    public function evaluate(\Neos\Eel\FlowQuery\FlowQuery $flowQuery, array $arguments)
+    {
+        if (!isset($arguments[0]) || empty($arguments[0])) {
+            throw new \Neos\Eel\FlowQuery\FlowQueryException('No Eel expression provided', 1332492243);
+        }
+        $expression = '${' . $arguments[0] . '}';
+        $context = $flowQuery->getContext();
+        $result = [];
+        foreach ($context as $node) {
+            $key = \Neos\Eel\Utility::evaluateEelExpression(
+                $expression,
+                $this->eelEvaluator,
+                ['node' => $node],
+                $this->defaultContextConfiguration
+            );
+            $key = is_string($key) ? $key : '_invalid';
+            $result[$key][] = $node;
+        }
+        ksort($result);
+
+        return $result;
+    }
 }

--- a/Classes/Dimaip/GroupBy/Eel/FlowQueryOperations/GroupByOperation.php
+++ b/Classes/Dimaip/GroupBy/Eel/FlowQueryOperations/GroupByOperation.php
@@ -3,6 +3,7 @@ namespace Dimaip\GroupBy\Eel\FlowQueryOperations;
 
 use Neos\ContentRepository\Domain\Model\NodeInterface;
 use Neos\Eel\FlowQuery\Operations\AbstractOperation;
+use Neos\Eel\ProtectedContextAwareInterface;
 use Neos\Flow\Annotations as Flow;
 
 /**
@@ -10,7 +11,7 @@ use Neos\Flow\Annotations as Flow;
  *
  * Takes an array of things and groups it by discriminator specified as as an Eel Expression
  */
-class GroupByOperation extends AbstractOperation
+class GroupByOperation extends AbstractOperation implements ProtectedContextAwareInterface
 {
     /**
      * {@inheritdoc}
@@ -82,5 +83,14 @@ class GroupByOperation extends AbstractOperation
         ksort($result);
 
         return $result;
+    }
+
+    /**
+     * @param string $methodName
+     * @return bool
+     */
+    public function allowsCallOfMethod($methodName)
+    {
+        return true;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "neos-package",
     "license": "GPL-3.0+",
     "require": {
-        "neos/neos": "~3.0"
+        "neos/neos": "~3.0 || ~4.0"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
Hi,

we're using this package in Neos 3.0 and also want to use it in a newer neos v4.0 project as well.
The changes i made include:
* Requirement of neos 3.0 or 4.0 in the composer.json
* Implementation of `ProtectedContextAwareInterface` to always allow calling this helper

and some other changes like PSR-2 code style reformat and missing annotations.

Thank you for providing this package and i would be very glad if you merged my changes.